### PR TITLE
fixup typespec

### DIFF
--- a/lib/essence/tokenizer.ex
+++ b/lib/essence/tokenizer.ex
@@ -43,7 +43,7 @@ defmodule Essence.Tokenizer do
   Splits a given `text` into tokens on punctuation, but omits the punctuation tokens.
   This method supports Unicode text.
   """
-  @spec split_with_punctuation(String.t) :: List.t
+  @spec split_without_punctuation(String.t) :: List.t
   def split_without_punctuation(text) do
     if String.ends_with?(text, "'s'") do
       [text]


### PR DESCRIPTION
A very simple fix for the `split_without_punctuation` typespec declaration.